### PR TITLE
fix: bump package in npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
 
-This package is deprecated due to low usage. We recommend to use SDKs for your auth provider instead, like the [msal package](https://www.npmjs.com/package/@azure/msal-browser) for Microsoft Azure AD.
+This package is deprecated due to low usage. We instead recommend to use SDK for your auth provider, like the [msal package](https://www.npmjs.com/package/@azure/msal-browser) for Microsoft Azure AD.
 
 ---
 


### PR DESCRIPTION
The [last PR](https://github.com/cognitedata/auth-wrapper/pull/25) didn't get released to npm. Trying to use semantic release convention (fix: )